### PR TITLE
Revert "Remove devel subpackage"

### DIFF
--- a/rpm/voicecall-qt5.spec
+++ b/rpm/voicecall-qt5.spec
@@ -25,6 +25,13 @@ BuildRequires:  oneshot
 %description
 %{summary}.
 
+%package devel
+Summary:    Voicecall development package
+Requires:   %{name} = %{version}-%{release}
+
+%description devel
+%{summary}.
+
 %package plugin-telepathy
 Summary:    Voicecall plugin for calls using telepathy
 Requires:   %{name} = %{version}-%{release}
@@ -89,7 +96,6 @@ fi
 %{_libdir}/libvoicecall.so.1
 %{_libdir}/libvoicecall.so.1.0
 %{_libdir}/libvoicecall.so.1.0.0
-%exclude %{_libdir}/libvoicecall.so
 %dir %{_libdir}/qt5/qml/org/nemomobile/voicecall
 %{_libdir}/qt5/qml/org/nemomobile/voicecall/libvoicecall.so
 %{_libdir}/qt5/qml/org/nemomobile/voicecall/qmldir
@@ -103,6 +109,10 @@ fi
 %{_userunitdir}/user-session.target.wants/voicecall-manager.service
 %{_datadir}/mapplauncherd/privileges.d/*
 %{_oneshotdir}/phone-move-recordings-dir
+
+%files devel
+%defattr(-,root,root,-)
+%{_libdir}/libvoicecall.so
 
 %files plugin-telepathy
 %defattr(-,root,root,-)


### PR DESCRIPTION
This reverts commit dd9305a56fbdc103c5d513f5a07257d4a5f3b9a1. It's not useless if you want to make voicecall plugin. It works if voicecall-manager is started without invoker but if you don't link against voicecall and start voicecall-manager with invoker it doesn't load the plugin.

supersedes #10 