### PR TITLE
Add a filtering API to VoiceCAllHandler

### DIFF
--- a/lib/src/abstractvoicecallhandler.cpp
+++ b/lib/src/abstractvoicecallhandler.cpp
@@ -41,6 +41,10 @@ QString AbstractVoiceCallHandler::statusText() const
             return "waiting";
         case STATUS_DISCONNECTED:
             return "disconnected";
+        case STATUS_REJECTED:
+            return "rejected";
+        case STATUS_IGNORED:
+            return "ignored";
 
         default:
             return "null";

--- a/lib/src/abstractvoicecallhandler.h
+++ b/lib/src/abstractvoicecallhandler.h
@@ -31,6 +31,7 @@ class AbstractVoiceCallHandler : public QObject
     Q_OBJECT
 
     Q_ENUMS(VoiceCallStatus)
+    Q_ENUMS(VoiceCallFilterAction)
 
     Q_PROPERTY(QString handlerId READ handlerId CONSTANT)
     Q_PROPERTY(AbstractVoiceCallProvider* provider READ provider)
@@ -56,7 +57,15 @@ public:
         STATUS_ALERTING,
         STATUS_INCOMING,
         STATUS_WAITING,
-        STATUS_DISCONNECTED
+        STATUS_DISCONNECTED,
+        STATUS_REJECTED,
+        STATUS_IGNORED
+    };
+
+    enum VoiceCallFilterAction {
+        ACTION_CONTINUE,
+        ACTION_IGNORE,
+        ACTION_REJECT
     };
 
     explicit AbstractVoiceCallHandler(QObject *parent = 0) : QObject(parent) {/* ... */}
@@ -102,6 +111,7 @@ public Q_SLOTS:
     virtual void sendDtmf(const QString &tones) = 0;
     virtual void merge(const QString &callHandle) = 0;
     virtual void split() = 0;
+    virtual void filter(VoiceCallFilterAction action) = 0;
 };
 
 #endif // ABSTRACTVOICECALLHANDLER_H

--- a/lib/src/voicecallmanagerinterface.h
+++ b/lib/src/voicecallmanagerinterface.h
@@ -123,6 +123,8 @@ public Q_SLOTS:
 
     virtual bool dial(const QString &providerId, const QString &msisdn) = 0;
 
+    virtual void setCallFiltering(bool on = true) = 0;
+
     virtual void playRingtone(const QString &ringtonePath) = 0;
     virtual void silenceRingtone() = 0;
 

--- a/plugins/commhistory/src/commhistoryplugin.cpp
+++ b/plugins/commhistory/src/commhistoryplugin.cpp
@@ -90,6 +90,12 @@ public:
             event.setEndTime(event.startTime().addSecs(handler.duration()));
             // No need to save the changes now, the voiceCallEnded will do it.
             break;
+        case AbstractVoiceCallHandler::STATUS_IGNORED:
+            event.setIncomingStatus(CommHistory::Event::Ignored);
+            break;
+        case AbstractVoiceCallHandler::STATUS_REJECTED:
+            event.setIncomingStatus(CommHistory::Event::Rejected);
+            break;
         default:
             break;
         }
@@ -121,9 +127,11 @@ public:
     void voiceCallEnded(const QString &id)
     {
         CommHistory::Event event = m_calls.take(id);
+
         if (event.direction() == CommHistory::Event::Inbound
+            && event.incomingStatus() == CommHistory::Event::Received
             && !event.isValid()) {
-            event.setIsMissedCall(true);
+            event.setIncomingStatus(CommHistory::Event::NotAnswered);
             event.setStartTime(QDateTime::currentDateTime());
             event.setEndTime(event.startTime());
         }

--- a/plugins/filter/filter.pro
+++ b/plugins/filter/filter.pro
@@ -1,0 +1,2 @@
+TEMPLATE = subdirs
+SUBDIRS = src

--- a/plugins/filter/src/filter.cpp
+++ b/plugins/filter/src/filter.cpp
@@ -1,0 +1,72 @@
+/*
+ * This file is a part of the Voice Call Manager project
+ *
+ * Copyright (C) 2024  Damien Caliste <dcaliste@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "filter.h"
+#include "filterlist.h"
+
+class Filter::Private
+{
+public:
+    Private()
+        : m_rejected(QString::fromLatin1("/sailfish/voicecall/filter/rejected-numbers"))
+        , m_ignored(QString::fromLatin1("/sailfish/voicecall/filter/ignored-numbers"))
+    {
+    }
+
+    FilterList m_rejected;
+    FilterList m_ignored;
+};
+
+Filter::Filter(QObject *parent)
+    : QObject(parent)
+    , d(new Private)
+{
+    connect(&d->m_rejected, &FilterList::changed,
+            this, &Filter::rejectedListChanged);
+    connect(&d->m_ignored, &FilterList::changed,
+            this, &Filter::ignoredListChanged);
+}
+
+Filter::~Filter()
+{
+}
+
+QStringList Filter::rejectedList() const
+{
+    return d->m_rejected.list();
+}
+
+QStringList Filter::ignoredList() const
+{
+    return d->m_ignored.list();
+}
+
+AbstractVoiceCallHandler::VoiceCallFilterAction Filter::evaluate(const AbstractVoiceCallHandler &incomingCall) const
+{
+    const QString incomingNumber = incomingCall.lineId();
+    if (d->m_rejected.match(incomingNumber)) {
+        return AbstractVoiceCallHandler::ACTION_REJECT;
+    } else if (d->m_ignored.match(incomingNumber)) {
+        return AbstractVoiceCallHandler::ACTION_IGNORE;
+    } else {
+        return AbstractVoiceCallHandler::ACTION_CONTINUE;
+    }
+}

--- a/plugins/filter/src/filter.h
+++ b/plugins/filter/src/filter.h
@@ -1,0 +1,51 @@
+/*
+ * This file is a part of the Voice Call Manager project
+ *
+ * Copyright (C) 2024  Damien Caliste <dcaliste@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef FILTER_H
+#define FILTER_H
+
+#include <QSharedPointer>
+#include <QObject>
+
+#include <abstractvoicecallhandler.h>
+
+class Filter : public QObject
+{
+    Q_OBJECT
+public:
+    Filter(QObject *parent = nullptr);
+    ~Filter();
+
+    QStringList ignoredList() const;
+    QStringList rejectedList() const;
+
+    AbstractVoiceCallHandler::VoiceCallFilterAction evaluate(const AbstractVoiceCallHandler &incomingCall) const;
+
+signals:
+    void ignoredListChanged();
+    void rejectedListChanged();
+
+private:
+    class Private;
+    QSharedPointer<Private> d;
+};
+
+#endif

--- a/plugins/filter/src/filterlist.cpp
+++ b/plugins/filter/src/filterlist.cpp
@@ -1,0 +1,67 @@
+/*
+ * This file is a part of the Voice Call Manager project
+ *
+ * Copyright (C) 2024  Damien Caliste <dcaliste@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "filterlist.h"
+
+#include <MGConfItem>
+
+class FilterList::Private
+{
+public:
+    Private(const QString &key)
+        : m_conf(key)
+    {
+    }
+
+    MGConfItem m_conf;
+};
+
+FilterList::FilterList(const QString &key, QObject *parent)
+    : QObject(parent)
+    , d(new Private(key))
+{
+    connect(&d->m_conf, &MGConfItem::valueChanged,
+            this, &FilterList::changed);
+}
+
+FilterList::~FilterList()
+{
+}
+
+QString FilterList::key() const
+{
+    return d->m_conf.key();
+}
+
+QStringList FilterList::list() const
+{
+    return d->m_conf.value().toStringList();
+}
+
+void FilterList::set(const QStringList &list)
+{
+    d->m_conf.set(list);
+}
+
+bool FilterList::match(const QString &number)
+{
+    return list().contains(number);
+}

--- a/plugins/filter/src/filterlist.h
+++ b/plugins/filter/src/filterlist.h
@@ -1,0 +1,48 @@
+/*
+ * This file is a part of the Voice Call Manager project
+ *
+ * Copyright (C) 2024  Damien Caliste <dcaliste@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef MATCHER_H
+#define MATCHER_H
+
+#include <QSharedPointer>
+#include <QObject>
+
+class FilterList : public QObject
+{
+    Q_OBJECT
+public:
+    FilterList(const QString &key, QObject *parent = nullptr);
+    ~FilterList();
+
+    bool match(const QString &number);
+    QString key() const;
+    QStringList list() const;
+    void set(const QStringList &list);
+
+signals:
+    void changed();
+
+private:
+    class Private;
+    QSharedPointer<Private> d;
+};
+
+#endif

--- a/plugins/filter/src/filterplugin.cpp
+++ b/plugins/filter/src/filterplugin.cpp
@@ -1,0 +1,98 @@
+/*
+ * This file is a part of the Voice Call Manager project
+ *
+ * Copyright (C) 2024  Damien Caliste <dcaliste@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "filterplugin.h"
+#include "filter.h"
+
+#include <voicecallmanagerinterface.h>
+#include <abstractvoicecallhandler.h>
+
+class FilterPlugin::Private
+{
+public:
+    Private()
+    {
+    }
+
+    VoiceCallManagerInterface *m_manager = nullptr;
+    Filter m_filter;
+};
+
+FilterPlugin::FilterPlugin(QObject *parent)
+    : AbstractVoiceCallManagerPlugin(parent), d(new Private)
+{
+}
+
+FilterPlugin::~FilterPlugin()
+{
+}
+
+QString FilterPlugin::pluginId() const
+{
+    return PLUGIN_NAME;
+}
+
+bool FilterPlugin::initialize()
+{
+    return true;
+}
+
+bool FilterPlugin::configure(VoiceCallManagerInterface *manager)
+{
+    d->m_manager = manager;
+
+    return true;
+}
+
+bool FilterPlugin::start()
+{
+    return resume();
+}
+
+bool FilterPlugin::suspend()
+{
+    d->m_manager->setCallFiltering(false);
+    disconnect(d->m_manager, &VoiceCallManagerInterface::voiceCallAdded,
+               this, &FilterPlugin::onVoiceCallAdded);
+    return true;
+}
+
+bool FilterPlugin::resume()
+{
+    d->m_manager->setCallFiltering();
+    connect(d->m_manager, &VoiceCallManagerInterface::voiceCallAdded,
+            this, &FilterPlugin::onVoiceCallAdded);
+    return true;
+}
+
+void FilterPlugin::finalize()
+{
+    suspend();
+}
+
+void FilterPlugin::onVoiceCallAdded(AbstractVoiceCallHandler *handler)
+{
+    if (!handler || !handler->isIncoming()) {
+        return;
+    }
+
+    handler->filter(d->m_filter.evaluate(*handler));
+}

--- a/plugins/filter/src/filterplugin.h
+++ b/plugins/filter/src/filterplugin.h
@@ -1,0 +1,59 @@
+/*
+ * This file is a part of the Voice Call Manager project
+ *
+ * Copyright (C) 2024  Damien Caliste <dcaliste@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+#ifndef FILTERPLUGIN_H
+#define FILTERPLUGIN_H
+
+#include <QSharedPointer>
+
+#include <abstractvoicecallmanagerplugin.h>
+
+class AbstractVoiceCallHandler;
+
+class FilterPlugin : public AbstractVoiceCallManagerPlugin
+{
+    Q_OBJECT
+
+    Q_PLUGIN_METADATA(IID "org.nemomobile.voicecall.filter")
+    Q_INTERFACES(AbstractVoiceCallManagerPlugin)
+
+public:
+    FilterPlugin(QObject *parent = 0);
+    ~FilterPlugin();
+
+    QString pluginId() const;
+
+public Q_SLOTS:
+    bool initialize();
+    bool configure(VoiceCallManagerInterface *manager);
+    bool start();
+    bool suspend();
+    bool resume();
+    void finalize();
+
+private Q_SLOTS:
+    void onVoiceCallAdded(AbstractVoiceCallHandler *handler);
+
+private:
+    class Private;
+    QSharedPointer<Private> d;
+};
+
+#endif // FILTERPLUGIN_H

--- a/plugins/filter/src/src.pro
+++ b/plugins/filter/src/src.pro
@@ -1,0 +1,16 @@
+include(../../plugin.pri)
+TARGET = voicecall-filter-plugin
+
+PKGCONFIG += mlite5
+
+DEFINES += PLUGIN_NAME=\\\"filter-plugin\\\"
+
+HEADERS += \
+    filterplugin.h \
+    filter.h \
+    filterlist.h
+
+SOURCES += \
+    filterplugin.cpp \
+    filter.cpp \
+    filterlist.cpp

--- a/plugins/mce/src/mceplugin.cpp
+++ b/plugins/mce/src/mceplugin.cpp
@@ -144,6 +144,8 @@ void McePlugin::onVoiceCallsChanged()
             {
             case AbstractVoiceCallHandler::STATUS_NULL:
             case AbstractVoiceCallHandler::STATUS_DISCONNECTED:
+            case AbstractVoiceCallHandler::STATUS_REJECTED:
+            case AbstractVoiceCallHandler::STATUS_IGNORED:
                 continue;
 
             case AbstractVoiceCallHandler::STATUS_INCOMING:

--- a/plugins/plugins.pro
+++ b/plugins/plugins.pro
@@ -1,5 +1,5 @@
 TEMPLATE = subdirs
-SUBDIRS = declarative providers playback-manager mce commhistory
+SUBDIRS = declarative providers playback-manager mce commhistory filter
 
 enable-ngf {
     SUBDIRS += ngf

--- a/plugins/providers/ofono/src/ofonovoicecallhandler.h
+++ b/plugins/providers/ofono/src/ofonovoicecallhandler.h
@@ -67,6 +67,7 @@ public Q_SLOTS:
     void hold(bool on = true);
     void deflect(const QString &target);
     void sendDtmf(const QString &tones);
+    void filter(VoiceCallFilterAction action);
 
     // TODO: unimplemented - JB#35997
     void merge(const QString &) {}

--- a/plugins/providers/telepathy/src/basechannelhandler.cpp
+++ b/plugins/providers/telepathy/src/basechannelhandler.cpp
@@ -33,3 +33,22 @@ QString BaseChannelHandler::subscriberId() const
     return properties.value("SubscriberIdentity").toString();
 }
 
+void BaseChannelHandler::filter(VoiceCallFilterAction action)
+{
+    if (status() != STATUS_NULL) {
+        return;
+    }
+
+    switch (action) {
+    case ACTION_REJECT:
+        hangup();
+        setStatus(STATUS_REJECTED);
+        break;
+    case ACTION_IGNORE:
+        setStatus(STATUS_IGNORED);
+        break;
+    default:
+        setStatus(STATUS_INCOMING);
+        break;
+    }
+}

--- a/plugins/providers/telepathy/src/basechannelhandler.h
+++ b/plugins/providers/telepathy/src/basechannelhandler.h
@@ -50,6 +50,13 @@ Q_SIGNALS:
     void channelMerged(Tp::ChannelPtr channel);
     void channelRemoved(Tp::ChannelPtr channel);
 
+public Q_SLOTS:
+    /*** AbstractVoiceCallHandler Implementation ***/
+    void filter(VoiceCallFilterAction action);
+
+protected:
+    virtual void setStatus(VoiceCallStatus newStatus) = 0;
+
 private:
     Q_DISABLE_COPY(BaseChannelHandler)
 };

--- a/plugins/providers/telepathy/src/callchannelhandler.h
+++ b/plugins/providers/telepathy/src/callchannelhandler.h
@@ -91,6 +91,8 @@ protected Q_SLOTS:
     void onFarstreamCreateChannelFinished(Tp::PendingOperation *op);
 
 protected:
+    void setStatus(VoiceCallStatus newStatus);
+
     void timerEvent(QTimerEvent *event);
 
     // TODO: unimplemented
@@ -98,8 +100,6 @@ protected:
     void removeChildCall(BaseChannelHandler */*handler*/) override {}
 
 private:
-    void setStatus(VoiceCallStatus newStatus);
-
     class CallChannelHandlerPrivate *d_ptr;
 
     Q_DISABLE_COPY(CallChannelHandler)

--- a/plugins/providers/telepathy/src/streamchannelhandler.cpp
+++ b/plugins/providers/telepathy/src/streamchannelhandler.cpp
@@ -476,8 +476,6 @@ void StreamChannelHandler::onStreamedMediaChannelReady(Tp::PendingOperation *op)
         setStatus(STATUS_ACTIVE);
     } else if (d->channel->isRequested()) {
         setStatus(STATUS_DIALING);
-    } else {
-        setStatus(STATUS_INCOMING);
     }
 
     d->isIncoming = !d->channel->isRequested();
@@ -773,6 +771,12 @@ void StreamChannelHandler::setStatus(VoiceCallStatus newStatus)
     Q_D(StreamChannelHandler);
     if (newStatus == d->status)
         return;
+
+    if (newStatus == STATUS_DISCONNECTED
+        && (d->status == STATUS_REJECTED
+            || d->status == STATUS_IGNORED)) {
+        return;
+    }
 
     d->status = newStatus;
     emit statusChanged(d->status);

--- a/plugins/providers/telepathy/src/streamchannelhandler.h
+++ b/plugins/providers/telepathy/src/streamchannelhandler.h
@@ -102,13 +102,13 @@ protected Q_SLOTS:
     void onStreamedMediaChannelConferenceMergeChannelFinished(Tp::PendingOperation *op);
 
 protected:
+    void setStatus(VoiceCallStatus newStatus);
+
     void timerEvent(QTimerEvent *event);
     void addChildCall(BaseChannelHandler *handler) override;
     void removeChildCall(BaseChannelHandler *handler) override;
 
 private:
-    void setStatus(VoiceCallStatus newStatus);
-
     class StreamChannelHandlerPrivate *d_ptr;
 
     Q_DISABLE_COPY(StreamChannelHandler)

--- a/rpm/voicecall-qt5.spec
+++ b/rpm/voicecall-qt5.spec
@@ -16,7 +16,7 @@ BuildRequires:  pkgconfig(Qt5Multimedia)
 BuildRequires:  pkgconfig(libresourceqt5)
 BuildRequires:  pkgconfig(libpulse-mainloop-glib)
 BuildRequires:  pkgconfig(ngf-qt5)
-BuildRequires:  pkgconfig(commhistory-qt5)
+BuildRequires:  pkgconfig(commhistory-qt5) >= 1.12.6
 BuildRequires:  pkgconfig(qt5-boostable)
 BuildRequires:  pkgconfig(nemodevicelock)
 BuildRequires:  pkgconfig(systemd)

--- a/rpm/voicecall-qt5.spec
+++ b/rpm/voicecall-qt5.spec
@@ -20,6 +20,7 @@ BuildRequires:  pkgconfig(commhistory-qt5) >= 1.12.6
 BuildRequires:  pkgconfig(qt5-boostable)
 BuildRequires:  pkgconfig(nemodevicelock)
 BuildRequires:  pkgconfig(systemd)
+BuildRequires:  pkgconfig(mlite5)
 BuildRequires:  oneshot
 %{_oneshot_requires_post}
 
@@ -50,6 +51,13 @@ Conflicts:  voicecall-qt5-plugin-telepathy
 BuildRequires:  pkgconfig(qofono-qt5)
 
 %description plugin-ofono
+%{summary}.
+
+%package plugin-voicecall-filter
+Summary:    Voicecall filter plugin
+Requires:   %{name} = %{version}-%{release}
+
+%description plugin-voicecall-filter
 %{summary}.
 
 %prep
@@ -124,4 +132,7 @@ fi
 %files plugin-ofono
 %defattr(-,root,root,-)
 %{_libdir}/voicecall/plugins/libvoicecall-ofono-plugin.so
+
+%files plugin-voicecall-filter
+%{_libdir}/voicecall/plugins/libvoicecall-filter-plugin.so
 

--- a/src/dbus/voicecallhandlerdbusadapter.cpp
+++ b/src/dbus/voicecallhandlerdbusadapter.cpp
@@ -192,7 +192,7 @@ QString VoiceCallHandlerDBusAdapter::statusText() const
 /*!
   Initiates the answering of this voice call, if its' an incoming call.
 
-  \sa status(), hangup(), deflect()
+  \sa status(), hangup(), deflect(), filter()
 */
 bool VoiceCallHandlerDBusAdapter::answer()
 {
@@ -205,13 +205,26 @@ bool VoiceCallHandlerDBusAdapter::answer()
 /*!
   Initiates hanging up this voice call, if its' currently not disconnected.
 
-  \sa status(), answer(), hold(), deflect()
+  \sa status(), answer(), hold(), deflect(), filter()
 */
 bool VoiceCallHandlerDBusAdapter::hangup()
 {
     TRACE
     Q_D(VoiceCallHandlerDBusAdapter);
     d->handler->hangup();
+    return true;
+}
+
+/*!
+  Initiates filtering this voice call, if it's an incoming call.
+
+  \sa status(), answer(), hold(), deflect(), hangup()
+*/
+bool VoiceCallHandlerDBusAdapter::filter(AbstractVoiceCallHandler::VoiceCallFilterAction action)
+{
+    TRACE
+    Q_D(VoiceCallHandlerDBusAdapter);
+    d->handler->filter(action);
     return true;
 }
 
@@ -314,4 +327,23 @@ QVariantMap VoiceCallHandlerDBusAdapter::getProperties()
 void VoiceCallHandlerDBusAdapter::onStatusChanged()
 {
     emit statusChanged(status(), statusText());
+}
+
+QDBusArgument &operator<<(QDBusArgument &argument, AbstractVoiceCallHandler::VoiceCallFilterAction action)
+{
+    int value = action;
+    argument.beginStructure();
+    argument << value;
+    argument.endStructure();
+    return argument;
+}
+
+const QDBusArgument &operator>>(const QDBusArgument &argument, AbstractVoiceCallHandler::VoiceCallFilterAction &action)
+{
+    int value;
+    argument.beginStructure();
+    argument >> value;
+    argument.endStructure();
+    action = static_cast<AbstractVoiceCallHandler::VoiceCallFilterAction>(value);
+    return argument;
 }

--- a/src/dbus/voicecallhandlerdbusadapter.h
+++ b/src/dbus/voicecallhandlerdbusadapter.h
@@ -24,6 +24,7 @@
 #include "abstractvoicecallhandler.h"
 
 #include <QDBusAbstractAdaptor>
+#include <QDBusArgument>
 #include <QDateTime>
 
 class VoiceCallHandlerDBusAdapter : public QDBusAbstractAdaptor
@@ -81,6 +82,7 @@ Q_SIGNALS:
 public Q_SLOTS:
     bool answer();
     bool hangup();
+    bool filter(AbstractVoiceCallHandler::VoiceCallFilterAction action);
     bool hold(bool on);
     bool deflect(const QString &target);
     void sendDtmf(const QString &tones);
@@ -101,5 +103,10 @@ private:
 
     Q_DECLARE_PRIVATE(VoiceCallHandlerDBusAdapter)
 };
+
+QDBusArgument &operator<<(QDBusArgument &argument, AbstractVoiceCallHandler::VoiceCallFilterAction action);
+const QDBusArgument &operator>>(const QDBusArgument &argument, AbstractVoiceCallHandler::VoiceCallFilterAction &action);
+
+Q_DECLARE_METATYPE(AbstractVoiceCallHandler::VoiceCallFilterAction)
 
 #endif // VOICECALLHANDLERDBUSADAPTER_H

--- a/src/dbus/voicecallmanagerdbusadapter.cpp
+++ b/src/dbus/voicecallmanagerdbusadapter.cpp
@@ -258,6 +258,13 @@ bool VoiceCallManagerDBusAdapter::dial(const QString &provider, const QString &m
     return true;
 }
 
+void VoiceCallManagerDBusAdapter::setCallFiltering(bool on)
+{
+    TRACE
+    Q_D(VoiceCallManagerDBusAdapter);
+    d->manager->setCallFiltering(on);
+}
+
 /*!
   Starts playing the ringtone for an incoming call.
  */

--- a/src/dbus/voicecallmanagerdbusadapter.h
+++ b/src/dbus/voicecallmanagerdbusadapter.h
@@ -83,6 +83,8 @@ Q_SIGNALS:
 public Q_SLOTS:
     bool dial(const QString &provider, const QString &msisdn);
 
+    void setCallFiltering(bool on = true);
+
     void playRingtone(const QString &ringtonePath);
     void silenceRingtone();
 

--- a/src/dbus/voicecallmanagerdbusservice.cpp
+++ b/src/dbus/voicecallmanagerdbusservice.cpp
@@ -28,6 +28,7 @@
 
 #include <QDBusError>
 #include <QDBusConnection>
+#include <QDBusMetaType>
 
 class VoiceCallManagerDBusServicePrivate
 {
@@ -48,6 +49,7 @@ VoiceCallManagerDBusService::VoiceCallManagerDBusService(QObject *parent)
     : AbstractVoiceCallManagerPlugin(parent), d_ptr(new VoiceCallManagerDBusServicePrivate(this))
 {
     TRACE
+    qDBusRegisterMetaType<AbstractVoiceCallHandler::VoiceCallFilterAction>();
 }
 
 VoiceCallManagerDBusService::~VoiceCallManagerDBusService()

--- a/src/voicecallmanager.h
+++ b/src/voicecallmanager.h
@@ -59,6 +59,8 @@ public Q_SLOTS:
 
     bool dial(const QString &providerId, const QString &msisdn);
 
+    void setCallFiltering(bool on = true) override;
+
     void playRingtone(const QString &ringtonePath);
     void silenceRingtone();
 


### PR DESCRIPTION
Following @abranson comment from #14 , I'm proposing an API extension allowing to filter out incoming calls. This API is adding a new method to `AbstractVoiceCallHandler` interface. Besides the existing `answer()` for an incoming call, I propose to add `filter(action)`. Calling the later, allow the providers (telepathy or oFono) to deal with the call (by hanging up or letting it ring) and change its status. It is thus adding two new status: REJECTED and IGNORED. Introducing these two new status allow not to change much from `voicecall-ui`. Indeed, in case of filtering, an incoming status will be changed for rejected or ignored, so the ui won't show up and it will not call `playRingTone()`, which is called only for the incoming status.

This is a clean solution that avoid to call playRingTone() and immediately after to call silenceRingTone() or stop it because the call has been ignored or hang up. It still has the following drawback compared to the initial #14 proposition:
- the ending call dialog is still shown. But this can be now tuned in the UI easily since we have the new status that tells that it's not an incoming call. Some slight adjustements should be done in voicecall-ui not to show the ending call dialog for these new status.
- the calls are still seen as missed call or plain call in the call history. Indeed, commhistory-daemon is listening via Telepathy, which cannot flag calls (as far as I know). I'm wondering if it could be a good idea to remove the telepathy code from commhistory-daemon and use voicecallmanager instead. It would simplify the code in my opinion and avoid some duplicates between commhistory-daemon and voicecallmanager.

Regarding the API itself, it is proposing the same filtering capabilities as the ones exposed by oFono and the ones from Android call screening response API (as pointed out by @abranson). Compared to Android, I didn't add the possibility to mess up with the call log and notifications. I think that the first is not a good idea (I don't want to have calls filtered out without having the possibility to supervise what happened), and I think that the second belongs to voicecall-ui, based on the new status. About the name, I remember that @pvuorela pointed out that `filter` might not be a good name, since one can confuse the action with filtering / sorting results. Android is using "screening" as a term. What do you think ? Should the new method be called "screenIncomingCall()" or something like that ?

I'm keeping the second commit implementing a filtering plugin based on this API, to show how it can be used. Depending on the discussion, I will close #14 if this PR is found to be a better approach.