### PR TITLE
Try to respect QML property CONSTANT

### DIFF
--- a/plugins/providers/telepathy/src/basechannelhandler.h
+++ b/plugins/providers/telepathy/src/basechannelhandler.h
@@ -41,6 +41,7 @@ public:
 
 Q_SIGNALS:
     /*** StreamedMediaChannelHandler Implementation ***/
+    void ready();
     void error(const QString &errorMessage);
     void invalidated(const QString &errorName, const QString &errorMessage);
 

--- a/plugins/providers/telepathy/src/callchannelhandler.cpp
+++ b/plugins/providers/telepathy/src/callchannelhandler.cpp
@@ -344,6 +344,8 @@ void CallChannelHandler::onCallChannelChannelReady(Tp::PendingOperation *op)
     }
 
     d->isIncoming = !d->channel->isRequested();
+
+    emit ready();
 }
 
 void CallChannelHandler::onCallChannelChannelInvalidated(Tp::DBusProxy *, const QString &errorName, const QString &errorMessage)

--- a/plugins/providers/telepathy/src/streamchannelhandler.cpp
+++ b/plugins/providers/telepathy/src/streamchannelhandler.cpp
@@ -470,6 +470,8 @@ void StreamChannelHandler::onStreamedMediaChannelReady(Tp::PendingOperation *op)
     }
 
     d->isIncoming = !d->channel->isRequested();
+
+    emit ready();
 }
 
 void StreamChannelHandler::onStreamedMediaChannelInvalidated(Tp::DBusProxy *, const QString &errorName, const QString &errorMessage)


### PR DESCRIPTION
I noticed that the telepathy plugin (which is used by default), is not respecting the property qualifiers of AbstractVoiceCallHandler class. There are two properties declared as CONSTANT: handlerId and isIncoming. While the first is set on construction, the second is set only when the channel becomes ready (so is not constant). I propose to delay the advertising of a new voicall handler up to when it is ready. Before that, none of its properties make sense anyway.

Actually, looking at the oFono plugin, it is already done like that, when a new call is created, it is first stored in a local map, and it emits VoicecallAdded only when the call becomes valid.

Doing so avoids the NULL state of the call handler and when advertised by the manager with VoicecallAdded, it is already in an incoming or active state. I think it makes more sense and avoid to call listeners at UI level or below, that will discard the callbacks because of the NULL state. I'm testing it at the moment.

Dealing with the CONSTANT qualifier, I'm wondering if some other properties could be switched to CONSTANT too, like the lineId for instance, or the startedAt and isMultiparty. It's an API break and some code may rely on listeners like `onLineIdChanged`, so it may not be a good idea to change the qualifier for these properties… But that would make the code more clear about what is immutable and what is not.

While looking at the streamchannelhandler code from the telepathy plugin, I'm proposing a second commit that slightly simplify the handling of the emergency status. I think there is no point in calling the setter in the constructor because the channel is never ready there, or at least the callback of becomeReady() is always called (otherwise the new channel would never have been added to the manager since it is only added from there). Then, one can treat the ServicePoint interface as other interfaces in the ready callback.

One last point I would like to raise, is in streamchannelhandler.cpp, there are some methods where a new interface object is created at each call (for instance `sendDTMF()`). These objects will be destroyed with their parent, the call handler, so I don't think there is any leak. But it seems strange to create a new object on each call of the method. Should one change that by storing the interface object in the Private class, or even better use the interface cache as done for the ServicePoint interface ?