### PR TITLE
[voicecall] Avoid warning printed when sending dtmf. Fixes JB#62233

### DIFF
--- a/plugins/declarative/src/voicecallhandler.h
+++ b/plugins/declarative/src/voicecallhandler.h
@@ -89,6 +89,7 @@ protected Q_SLOTS:
     void initialize(bool notifyError = false);
 
     void onPendingCallFinished(QDBusPendingCallWatcher *watcher);
+    void onPendingVoidCallFinished(QDBusPendingCallWatcher *watcher);
     void onDurationChanged(int duration);
     void onStatusChanged(int status, const QString &statusText);
     void onLineIdChanged(const QString &lineId);


### PR DESCRIPTION
The existing onPendingCallFinished() assumes that the d-bus call returned a boolean. Works for everything else but not the dtmf method which returns void. Thus added a separate callback handler for that return type.

While at it switched to new signal connection syntax.

cc @dcaliste  - noticed while making a smoke test with your previous PR.