### PR TITLE
[voicecall] Create a plugin logging calls to CommHistory.

### DIFF
--- a/lib/src/abstractvoicecallhandler.h
+++ b/lib/src/abstractvoicecallhandler.h
@@ -66,6 +66,7 @@ public:
 
     virtual QString handlerId() const = 0;
     virtual QString lineId() const = 0;
+    virtual QString subscriberId() const = 0;
     virtual QDateTime startedAt() const = 0;
     virtual int duration() const = 0;
     virtual bool isIncoming() const = 0;

--- a/plugins/commhistory/commhistory.pro
+++ b/plugins/commhistory/commhistory.pro
@@ -1,0 +1,2 @@
+TEMPLATE = subdirs
+SUBDIRS = src

--- a/plugins/commhistory/src/commhistoryplugin.cpp
+++ b/plugins/commhistory/src/commhistoryplugin.cpp
@@ -1,0 +1,216 @@
+/*
+ * This file is a part of the Voice Call Manager project
+ *
+ * Copyright (C) 2024  Damien Caliste <dcaliste@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "commhistoryplugin.h"
+
+#include <common.h>
+#include <voicecallmanagerinterface.h>
+#include <abstractvoicecallhandler.h>
+
+#include <CommHistory/EventModel>
+#include <CommHistory/Event>
+
+#include <QTimer>
+
+static QString activeCallProp = QLatin1String("activeCall");
+
+class CommHistoryPlugin::Private
+{
+public:
+    Private()
+    {
+        m_timer.setInterval(5 * 60000);
+        connect(&m_timer, &QTimer::timeout,
+                [this] () {
+                    for (const QString &id : m_calls.keys()) {
+                        CommHistory::Event &event = m_calls[id];
+                        storeCall(&event);
+                    }
+                });
+    }
+
+    VoiceCallManagerInterface *m_manager = nullptr;
+    QMap<QString, CommHistory::Event> m_calls;
+    QTimer m_timer;
+    CommHistory::EventModel m_eventModel;
+
+    void newVoiceCall(const AbstractVoiceCallHandler &handler)
+    {
+        CommHistory::Event event;
+        event.setType(CommHistory::Event::CallEvent);
+        event.setLocalUid(handler.provider()->providerId());
+        event.setRecipients(CommHistory::Recipient(event.localUid(),
+                                                   handler.lineId()));
+        event.setSubscriberIdentity(handler.subscriberId());
+        event.setStartTime(QDateTime::currentDateTime());
+        event.setEndTime(event.startTime());
+        event.setIsEmergencyCall(handler.isEmergency());
+        event.setDirection(handler.isIncoming() ? CommHistory::Event::Inbound
+                                                : CommHistory::Event::Outbound);
+
+        if (m_calls.isEmpty()) {
+            m_timer.start();
+        }
+        storeCall(&event);
+
+        m_calls.insert(handler.handlerId(), event);
+    }
+
+    void onVoiceCallStatusChanged(const AbstractVoiceCallHandler &handler)
+    {
+        CommHistory::Event &event = m_calls[handler.handlerId()];
+
+        switch (handler.status()) {
+        case AbstractVoiceCallHandler::STATUS_ACTIVE:
+            event.setStartTime(QDateTime::currentDateTime());
+            event.setEndTime(event.startTime());
+            event.setExtraProperty(activeCallProp, true);
+            storeCall(&event);
+            break;
+        case AbstractVoiceCallHandler::STATUS_DISCONNECTED:
+            event.setEndTime(event.startTime().addSecs(handler.duration()));
+            // No need to save the changes now, the voiceCallEnded will do it.
+            break;
+        default:
+            break;
+        }
+    }
+
+    void onVoiceCallEmergencyChanged(const AbstractVoiceCallHandler &handler)
+    {
+        CommHistory::Event &event = m_calls[handler.handlerId()];
+        event.setIsEmergencyCall(handler.isEmergency());
+        storeCall(&event);
+    }
+
+    void onVoiceCallDurationChanged(const AbstractVoiceCallHandler &handler)
+    {
+        CommHistory::Event &event = m_calls[handler.handlerId()];
+        event.setEndTime(event.startTime().addSecs(handler.duration()));
+    }
+
+    void storeCall(CommHistory::Event *event)
+    {
+        // In CommHistory::Event, events become valid after being added to a model.
+        if (!event->isValid() && !m_eventModel.addEvent(*event)) {
+            qCWarning(voicecall) << "cannot add event to call history";
+        } else if (event->isValid() && !m_eventModel.modifyEvent(*event)) {
+            qCWarning(voicecall) << "cannot modify event in call history";
+        }
+    }
+
+    void voiceCallEnded(const QString &id)
+    {
+        CommHistory::Event event = m_calls.take(id);
+        event.setIsMissedCall(event.direction() == CommHistory::Event::Inbound
+                              && !event.extraProperty(activeCallProp).isValid());
+        event.removeExtraProperty(activeCallProp);
+        if (event.isMissedCall()) {
+            event.setStartTime(QDateTime::currentDateTime());
+            event.setEndTime(event.startTime());
+        }
+        storeCall(&event);
+        if (m_calls.isEmpty()) {
+            m_timer.stop();
+        }
+    }
+};
+
+CommHistoryPlugin::CommHistoryPlugin(QObject *parent)
+    : AbstractVoiceCallManagerPlugin(parent), d(new Private)
+{
+}
+
+CommHistoryPlugin::~CommHistoryPlugin()
+{
+}
+
+QString CommHistoryPlugin::pluginId() const
+{
+    return PLUGIN_NAME;
+}
+
+bool CommHistoryPlugin::initialize()
+{
+    return true;
+}
+
+bool CommHistoryPlugin::configure(VoiceCallManagerInterface *manager)
+{
+    d->m_manager = manager;
+
+    return true;
+}
+
+bool CommHistoryPlugin::start()
+{
+    return resume();
+}
+
+bool CommHistoryPlugin::suspend()
+{
+    disconnect(d->m_manager, &VoiceCallManagerInterface::voiceCallRemoved,
+               this, &CommHistoryPlugin::onVoiceCallRemoved);
+    disconnect(d->m_manager, &VoiceCallManagerInterface::voiceCallAdded,
+               this, &CommHistoryPlugin::onVoiceCallAdded);
+    return true;
+}
+
+bool CommHistoryPlugin::resume()
+{
+    connect(d->m_manager, &VoiceCallManagerInterface::voiceCallAdded,
+            this, &CommHistoryPlugin::onVoiceCallAdded);
+    connect(d->m_manager, &VoiceCallManagerInterface::voiceCallRemoved,
+            this, &CommHistoryPlugin::onVoiceCallRemoved);
+    return true;
+}
+
+void CommHistoryPlugin::finalize()
+{
+    suspend();
+}
+
+void CommHistoryPlugin::onVoiceCallAdded(AbstractVoiceCallHandler *handler)
+{
+    if (!handler) {
+        return;
+    }
+
+    connect(handler, &AbstractVoiceCallHandler::emergencyChanged,
+            this, [this, handler] (bool) {
+                d->onVoiceCallEmergencyChanged(*handler);
+            });
+    connect(handler, &AbstractVoiceCallHandler::statusChanged,
+            this, [this, handler] (AbstractVoiceCallHandler::VoiceCallStatus) {
+                d->onVoiceCallStatusChanged(*handler);
+            });
+    connect(handler, &AbstractVoiceCallHandler::durationChanged,
+            this, [this, handler] (bool) {
+                d->onVoiceCallDurationChanged(*handler);
+            });
+
+    d->newVoiceCall(*handler);
+}
+
+void CommHistoryPlugin::onVoiceCallRemoved(const QString &handlerId)
+{
+    d->voiceCallEnded(handlerId);
+}

--- a/plugins/commhistory/src/commhistoryplugin.h
+++ b/plugins/commhistory/src/commhistoryplugin.h
@@ -1,0 +1,60 @@
+/*
+ * This file is a part of the Voice Call Manager project
+ *
+ * Copyright (C) 2024  Damien Caliste <dcaliste@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+#ifndef COMMHISTORYPLUGIN_H
+#define COMMHISTORYPLUGIN_H
+
+#include <QSharedPointer>
+
+#include <abstractvoicecallmanagerplugin.h>
+
+class AbstractVoiceCallHandler;
+
+class CommHistoryPlugin : public AbstractVoiceCallManagerPlugin
+{
+    Q_OBJECT
+
+    Q_PLUGIN_METADATA(IID "org.nemomobile.voicecall.commhistory")
+    Q_INTERFACES(AbstractVoiceCallManagerPlugin)
+
+public:
+    CommHistoryPlugin(QObject *parent = 0);
+    ~CommHistoryPlugin();
+
+    QString pluginId() const;
+
+public Q_SLOTS:
+    bool initialize();
+    bool configure(VoiceCallManagerInterface *manager);
+    bool start();
+    bool suspend();
+    bool resume();
+    void finalize();
+
+private Q_SLOTS:
+    void onVoiceCallAdded(AbstractVoiceCallHandler *handler);
+    void onVoiceCallRemoved(const QString &handlerId);
+
+private:
+    class Private;
+    QSharedPointer<Private> d;
+};
+
+#endif // COMMHISTORYPLUGIN_H

--- a/plugins/commhistory/src/src.pro
+++ b/plugins/commhistory/src/src.pro
@@ -1,0 +1,12 @@
+include(../../plugin.pri)
+TARGET = voicecall-commhistory-plugin
+
+PKGCONFIG += commhistory-qt5
+
+DEFINES += PLUGIN_NAME=\\\"commhistory-plugin\\\"
+
+HEADERS += \
+    commhistoryplugin.h
+
+SOURCES += \
+    commhistoryplugin.cpp

--- a/plugins/plugins.pro
+++ b/plugins/plugins.pro
@@ -1,5 +1,5 @@
 TEMPLATE = subdirs
-SUBDIRS = declarative providers playback-manager mce
+SUBDIRS = declarative providers playback-manager mce commhistory
 
 enable-ngf {
     SUBDIRS += ngf

--- a/plugins/providers/ofono/src/ofonovoicecallhandler.cpp
+++ b/plugins/providers/ofono/src/ofonovoicecallhandler.cpp
@@ -120,6 +120,13 @@ QString OfonoVoiceCallHandler::lineId() const
     return d->ofonoVoiceCall->lineIdentification();
 }
 
+QString OfonoVoiceCallHandler::subscriberId() const
+{
+    TRACE
+    Q_D(const OfonoVoiceCallHandler);
+    return d->ofonoVoiceCall->lineIdentification();
+}
+
 QDateTime OfonoVoiceCallHandler::startedAt() const
 {
     TRACE

--- a/plugins/providers/ofono/src/ofonovoicecallhandler.h
+++ b/plugins/providers/ofono/src/ofonovoicecallhandler.h
@@ -43,6 +43,7 @@ public:
 
     QString handlerId() const;
     QString lineId() const;
+    QString subscriberId() const override;
     QDateTime startedAt() const;
     int duration() const;
     bool isIncoming() const;

--- a/plugins/providers/telepathy/src/basechannelhandler.cpp
+++ b/plugins/providers/telepathy/src/basechannelhandler.cpp
@@ -26,3 +26,10 @@ BaseChannelHandler::BaseChannelHandler(QObject *parent)
 {
 
 }
+
+QString BaseChannelHandler::subscriberId() const
+{
+    const QVariantMap properties = channel()->immutableProperties();
+    return properties.value("SubscriberIdentity").toString();
+}
+

--- a/plugins/providers/telepathy/src/basechannelhandler.h
+++ b/plugins/providers/telepathy/src/basechannelhandler.h
@@ -39,6 +39,8 @@ public:
     virtual void addChildCall(BaseChannelHandler *handler) = 0;
     virtual void removeChildCall(BaseChannelHandler *handler) = 0;
 
+    QString subscriberId() const override;
+
 Q_SIGNALS:
     /*** StreamedMediaChannelHandler Implementation ***/
     void ready();

--- a/rpm/voicecall-qt5.spec
+++ b/rpm/voicecall-qt5.spec
@@ -16,6 +16,7 @@ BuildRequires:  pkgconfig(Qt5Multimedia)
 BuildRequires:  pkgconfig(libresourceqt5)
 BuildRequires:  pkgconfig(libpulse-mainloop-glib)
 BuildRequires:  pkgconfig(ngf-qt5)
+BuildRequires:  pkgconfig(commhistory-qt5)
 BuildRequires:  pkgconfig(qt5-boostable)
 BuildRequires:  pkgconfig(nemodevicelock)
 BuildRequires:  pkgconfig(systemd)
@@ -105,6 +106,7 @@ fi
 %{_libdir}/voicecall/plugins/libvoicecall-playback-manager-plugin.so
 %{_libdir}/voicecall/plugins/libvoicecall-ngf-plugin.so
 %{_libdir}/voicecall/plugins/libvoicecall-mce-plugin.so
+%{_libdir}/voicecall/plugins/libvoicecall-commhistory-plugin.so
 %{_userunitdir}/voicecall-manager.service
 %{_userunitdir}/user-session.target.wants/voicecall-manager.service
 %{_datadir}/mapplauncherd/privileges.d/*


### PR DESCRIPTION
Directly write to commhistory database using an EventModel. This is basically trying to do the same job than what is done in sailfihsos/commhistory-daemon/src/streamchannellistener.cpp.

There may be some differences, I missed. but at least one missing functionality is the support for video calls. Otherwise, I tried to replicate the same behaviour, using the AbstractVoicecallHandler API instead of the Telepathy one:
- it adds an entry on call creation (a minor difference here, I didn't replicate the optimisation to postpone the writing for incoming calls),
- it updates its duration every 5 minutes,
- the starting date time is when the call becomes active and not when the call arrive in the modem,
- for missed calls, the time of the call is when the call ended and becomes actually a missed call.

There still is another minor difference : the streamchannellistener is using ChannelListener::targetId() as the remote phone number, while this patch is using AbstractVoicecallHandler::lineId(). The former is using `TELEPATHY_CHANNEL_INTERFACE_PERSISTENT_ID` while the later is using StreamedMediaChannelPtr::targetId(). It makes a difference for instance if I'm dialing `0123456789` on the device, this is currently logged as `+33123456789` while this patch is logging it as `0123456789`. I don't know if it makes a big difference, in the log point of view. Maybe, if I dial at home a number without international prefix and move abroad and reuse the same number from the call history, it will fail... That being said, for numbers in the address book, even if it logs `0123456789` it is then presented as the address book number (_i.e._ with an international prefix, if it is stored with).

@pvuorela, when using in conjunction with the current logging function in commhitory-daemon, we obtain duplicated entries in the call history that allows to check the correctness of this proposition.

Compared to the code in streamchannellistener, I find the code a bit simpler to read and maintain with this approach. It can easily be extended to save new call status (ignored and blocked) to the new incoming status of events.