### PR TITLE
Fix the missed call counter issue

### DIFF
--- a/plugins/commhistory/src/commhistoryplugin.cpp
+++ b/plugins/commhistory/src/commhistoryplugin.cpp
@@ -109,11 +109,11 @@ public:
 
     void storeCall(CommHistory::Event *event)
     {
-        // In CommHistory::Event, events become valid after being added to a model.
-        if (!event->isValid() && !m_eventModel.addEvent(*event)) {
-            qCWarning(voicecall) << "cannot add event to call history";
-        } else if (event->isValid() && !m_eventModel.modifyEvent(*event)) {
+        // In CommHistory::Event, events are valid when existing in a model.
+        if (event->isValid() && !m_eventModel.modifyEvent(*event)) {
             qCWarning(voicecall) << "cannot modify event in call history";
+        } else if (!event->isValid() && !m_eventModel.addEvent(*event)) {
+            qCWarning(voicecall) << "cannot add event to call history";
         }
     }
 


### PR DESCRIPTION
@pvuorela, I believe these two commits are fixing the behaviour we observed, about the missed call counter.

It was due to the fact that the old commhistory-daemon code was delaying the storage of event for incoming calls. Then, missed call status was known when receiving the eventsAdded signal from D-Bus, while without the patch, the missed call status is known in a later update, not properly treated in libcommhistory/src/callmodel.cpp.

I think it's much simpler to follow the old behaviour. The code to handle the missed call counter is very complex in callmodel.cpp and I prefer not to disturb it. In addition, doing it here saves one D-Bus message.

I've also fixed an issue that emits the eventsUpdate spuriously and was further confusing the counter.