### PR TITLE
[spec] Fix qmake calls in %build. JB#63683

### DIFF
--- a/rpm/voicecall-qt5.spec
+++ b/rpm/voicecall-qt5.spec
@@ -81,9 +81,7 @@ Tests for %{name}.
 
 %build
 
-%qmake5 
-
-qmake -qt=5 CONFIG+=enable-ngf CONFIG+=enable-audiopolicy CONFIG+=enable-telepathy CONFIG+=enable-nemo-devicelock CONFIG+=install-servicefiles "PROJECT_VERSION=%{version}" "PKGCONFIG_LIB=%{_lib}"
+%qmake5 CONFIG+=enable-ngf CONFIG+=enable-audiopolicy CONFIG+=enable-telepathy CONFIG+=enable-nemo-devicelock CONFIG+=install-servicefiles "PROJECT_VERSION=%{version}" "PKGCONFIG_LIB=%{_lib}"
 %make_build
 
 %install


### PR DESCRIPTION
The second call overwrote things set by the qmake call in the macro.